### PR TITLE
fix: correct Sucessfully->Successfully typo in MessageBox dialog

### DIFF
--- a/CustomRules.cs
+++ b/CustomRules.cs
@@ -3864,7 +3864,7 @@ namespace Fiddler
                     FiddlerObject.UI.actLoadSessionArchive(openCapture.FileName);
                 }
                 // Run regexes
-                DialogResult dialogEKFiddleRunRegexes = MessageBox.Show("Sucessfully loaded: " + openCapture.SafeFileName + "\n" + "\n" 
+                DialogResult dialogEKFiddleRunRegexes = MessageBox.Show("Successfully loaded: " + openCapture.SafeFileName + "\n" + "\n" 
                  + "Would you like to run Regexes?", "EKFiddle", MessageBoxButtons.YesNo, MessageBoxIcon.Information);
                 if(dialogEKFiddleRunRegexes == DialogResult.Yes)
                 {


### PR DESCRIPTION
Fix typo in CustomRules.cs line 3867: `Sucessfully` → `Successfully` in user-facing MessageBox dialog.

Verified via `gh search code` - user-visible dialog message shown after loading session archive.

**Change:** 1 file, 1 line

Gate-1✅ (no existing PR for this fix) | Gate-2✅ (1 OPEN PR, unrelated) | Gate-3✅ (1 commit)